### PR TITLE
Fixed an incorrectly delimited column name in sma_mysql.c.

### DIFF
--- a/sma_mysql.c
+++ b/sma_mysql.c
@@ -142,7 +142,7 @@ int install_mysql_tables( ConfType * conf, FlagType * flag, char *SCHEMA )
            `Units` varchar(20) DEFAULT NULL, \
            `CHANGETIME` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP, \
            PRIMARY KEY (`id`), \
-           UNIQUE KEY 'DateTime'(`DateTime`,`Inverter`,`Serial`,`Description`) \
+           UNIQUE KEY `DateTime`(`DateTime`,`Inverter`,`Serial`,`Description`) \
            ) ENGINE=MyISAM" );
        if (flag->debug == 1) printf("%s\n",SQLQUERY);
        DoQuery(SQLQUERY);


### PR DESCRIPTION
Line 145 uses a single apostrophe to delimit the DateTime key name, whereas it should use a backtick.
UNIQUE KEY `DateTime`(`DateTime`,`Inverter`,`Serial`,`Description`) \

Without this you get the error:
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''DateTime'(`DateTime`,`Inverter`,`Serial`,`Description`)