### PR TITLE
Fix compilation on Debian based systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 ARCH := $(shell getconf LONG_BIT)
 C_FLAGS_64 := -L/usr/lib64/mysql
 C_FLAGS_32 := -L/usr/lib/mysql
+LIBXML_INCLUDE := $(shell pkg-config --cflags libxml-2.0)
 
 
 smatool: smatool.o repost.o sma_mysql.o almanac.o sb_commands.o sma_struct.h
 	gcc smatool.o repost.o sma_mysql.o almanac.o sb_commands.o -fstack-protector-all -O2 -Wall $(C_FLAGS_$(ARCH)) -lxml2 -lmysqlclient -lbluetooth -lcurl -lm -o smatool 
 smatool.o: smatool.c sma_mysql.h
-	gcc -O2 -c smatool.c
+	gcc $(LIBXML_INCLUDE) -O2 -c smatool.c
 repost.o: repost.c sma_mysql.h
 	gcc -O2 -c repost.c
 sma_mysql.o: sma_mysql.c

--- a/smatool.c
+++ b/smatool.c
@@ -33,8 +33,8 @@
 #include <curl/curl.h>
 #include "repost.h"
 #include "sma_mysql.h"
-#include <libxml2/libxml/parser.h>
-#include <libxml2/libxml/xpath.h>
+#include <libxml/parser.h>
+#include <libxml/xpath.h>
 
 
 /*


### PR DESCRIPTION
This patch fixes compilation on Ubuntu (and most likely on other recent Debian-based systems).

As the libxml2 header files are included from within the other libxml2 header files using `#include <libxml/...h`,
reference the header files similarly from within `smatool.c`. Because if this change, the `/usr/include/libxml2` path needs to be specified to the compiler, so it can find the libxml2 header files. I used `pkg-config` to make it independent of the Linux distribution being used.

This fix should close #144.